### PR TITLE
Allow the user to set the desired OCP version

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,15 @@ clean              ==> Delete the OCP cluster
 help               ==> Print usage
 ```
 
+# Debugging your fork
+
+## Debugging Ansible
+To debug your fork, you may set the following in your `values.yaml` file to make the ansible playbook use your branch
+```yaml
+repo_to_clone: < The URL for your fork >
+version_to_clone: < Name of your branch >
+```
+
 ### More Info
 
 https://docs.google.com/document/d/1pxHJ4elXjRVgEZXK5U1kSmMQd21wMcXFO567ORzgCKY/edit?usp=sharing

--- a/README.md
+++ b/README.md
@@ -63,6 +63,11 @@ You can either use the provided `Ansible` playbook or run the steps manually
 
     The README uses a plain-text `values.yml` file. Consider using `ansible-vault` as the file includes sensitive information
 
+    4.1. You may optionally set the desired OCP version be setting
+    ```yaml
+    ocp_version: <Your desired OCP version>
+    ```
+
 5. Execute Ansible Playbook
 
     With Root Access

--- a/README.md
+++ b/README.md
@@ -119,9 +119,15 @@ and export the file path
 6. Clone ocp-dev-cluster repository and change directory to it
     ```bash
     git clone https://github.com/nirarg/ocp-dev-cluster.git
+    cd ocp-dev-cluster
     ```
 
-7. In case you need, you can change any Environment Variable configured in `dev-cluster`
+7. If you wish to set the OCP version to a specific GA version, you may set the `OCP_VERSION` environment variable
+    ```bash
+    export OCP_VERSION=<Your desired OCP version>
+    ```
+
+8. In case you need, you can change any Environment Variable configured in `dev-cluster`
 
 # Usage
 

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -4,6 +4,7 @@
     pull_secret_remote_path: "{{ansible_user_dir}}/pull_secret"
     repo_local_dir: "{{ansible_user_dir}}/ansible/ocp-dev-cluster"
     dev_cluster_command: "all"
+    this_repo: "https://github.com/nirarg/ocp-dev-cluster.git"
   gather_facts: true
   become: true
   tasks:
@@ -41,8 +42,9 @@
 
   - name: Get repo
     ansible.builtin.git:
-      repo: "https://github.com/nirarg/ocp-dev-cluster.git"
+      repo: "{{repo_to_clone | default(this_repo)}}"
       dest: "{{ repo_local_dir }}"
+      version: "{{version_to_clone | default('HEAD')}}"
 
   - name: Run cluster creation
     ansible.builtin.shell:

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -50,5 +50,6 @@
     environment:
       CI_TOKEN: "{{ ci_token }}"
       PULL_SECRET_PATH: "{{ pull_secret_remote_path }}"
+      OCP_VERSION: "{{ ocp_version | default('') }}"
     async: 10800
     poll: 300

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -13,6 +13,7 @@
       username: "{{ rh_username }}"
       password: "{{ rh_password }}"
       auto_attach: true
+      force_register: true
     retries: 3
     delay: 5
 

--- a/dev-cluster
+++ b/dev-cluster
@@ -19,9 +19,9 @@ export NFS_SERVER=192.168.122.1
 
 function devcluster::usage() {
 	echo "Usage:
-	
+
 	./dev-cluster <cammand>
-			
+
 		create-cluster     ==> Create new OCP cluster
 		install-nfs-class  ==> Install NFS Storage Class on the cluster
 		install-metallb    ==> Install MetalLB (LoadBalancer) on the cluster
@@ -34,14 +34,14 @@ function devcluster::usage() {
 }
 
 function devcluster::clean() {
-	if [ -d "dev-scripts" ] 
+	if [ -d "dev-scripts" ]
 	then
 		cd dev-scripts
 		make clean
 		cd ..
 		rm -rf dev-scripts
 	fi
-	if [ -d "${WORKING_DIR}" ] 
+	if [ -d "${WORKING_DIR}" ]
 	then
 		rm -rf ${WORKING_DIR}
 	fi
@@ -65,6 +65,10 @@ function devcluster::create-cluster() {
 	cd dev-scripts
 	cp config_example.sh config_${USER}.sh
 	sed -i 's/export CI_TOKEN=''/export CI_TOKEN='${CI_TOKEN}'/g' config_${USER}.sh
+	if [[ -n "${OCP_VERSION}" ]]; then
+		echo "export OPENSHIFT_RELEASE_TYPE=ga" >> config_${USER}.sh
+		echo "export OPENSHIFT_VERSION=${OCP_VERSION}" >> config_${USER}.sh
+	fi
 	make
 	cd ..
 
@@ -150,7 +154,7 @@ function devcluster::install-cnv() {
 	    fi
   	  fi
 	done
-	
+
 	if [[ $(oc get csv -n openshift-cnv ${CSV} -o jsonpath={.status.phase}) != "Succeeded" ]]; then
 	  echo "Error: Failed to deploy CNV"
 	  echo "CSV ${CSV} YAML"

--- a/manifests/cnv/cnv.yaml
+++ b/manifests/cnv/cnv.yaml
@@ -21,5 +21,4 @@ spec:
   source: redhat-operators
   sourceNamespace: openshift-marketplace
   name: kubevirt-hyperconverged
-  startingCSV: kubevirt-hyperconverged-operator.v4.10.0
   channel: "stable"


### PR DESCRIPTION
## OCP Version
Add an environment variable and Ansible value to allow the user to set the desired OCP version (for now only GA versions are supported)

## Force registration
To allow rerunning the script

## Not specify CSV
While it might slow the process, it removed the need to maintain the value

## Hooks for Fork
Easy way to test your changes